### PR TITLE
Fix HTTP 400 Neynar response

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -8,5 +8,7 @@ RECIPIENT_FID=
 TIPPER_FID=
 # Set to 'true' if the lack of an allowance should be ignored and the tool should run up until the point of actually making a post on Farcaster
 DRY_RUN=
+# Set to 'true' if you want the action to run immediately
+RUN_IMMEDIATELY=
 # The schedule by which this utility should wake and and tip; see https://crontab.guru/ to test your schedule
 CRON_SCHEDULE=0 0 * * *

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ After=network.target
 [Service]
 WorkingDirectory=/opt/wakentip
 ExecStart=node --env-file=.env index.js
-Type=notify
+Type=simple
 Restart=always
 
 [Install]

--- a/index.js
+++ b/index.js
@@ -2,21 +2,24 @@ import { NeynarAPIClient, Configuration } from "@neynar/nodejs-sdk";
 import { default as axios } from "axios";
 import { default as cron } from 'node-cron';
 
-const cronSchedule = process.env.CRON_SCHEDULE;
-if (!cronSchedule) {
-    console.error("Missing CRON_SCHEDULE")
+if (process.env.RUN_IMMEDIATELY === "true") {
+    await runTip();
+} else {
+    const cronSchedule = process.env.CRON_SCHEDULE;
+    if (!cronSchedule) {
+        console.error("Missing CRON_SCHEDULE")
+        
+        process.exit(1);
+    }
     
-    process.exit(1);
+    console.log(`Running wakentip according to cron schedule '${cronSchedule}'`);
+    
+    cron.schedule(cronSchedule, () => {
+        runTip().catch(err => {
+            console.error(err)
+        });
+    })
 }
-
-console.log(`Running wakentip according to cron schedule '${cronSchedule}'`);
-
-cron.schedule(cronSchedule, () => {
-    runTip().catch(err => {
-        console.error(err)
-    });
-})
-
 
 async function runTip() {
     const dryRun = process.env.DRY_RUN === "true";
@@ -108,7 +111,7 @@ async function runTip() {
             signerUuid: neynarSignerUUID,
             text: postText,
             parent: recipientCastHash,
-            idem: nonce,
+            idem: `${nonce}`,
         })
     }
 }


### PR DESCRIPTION
Previously, the `idem` field was being sent as a number, not a string. This caused Neynar to reject the request.

This also fixes the systemctl template to avoid systemctl killing the service due to a perceived timeout.